### PR TITLE
Make project properties configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,18 @@ To use this plugin you should add it in your pom.xml
                 <version>1.0</version>
                 <configuration>
                     <filename>build.info</filename>
+                    <projectProperties>
+                        <projectProperty>project[.parent].id</projectProperty>
+                        <projectProperty>project[.parent].groupId</projectProperty>
+                        <projectProperty>project[.parent].artifactId</projectProperty>
+                        <projectProperty>project[.parent].version</projectProperty>
+                        <projectProperty>project[.parent].name</projectProperty>
+                        <projectProperty>project[.parent].description</projectProperty>
+                        <projectProperty>project[.parent].modelVersion</projectProperty>
+                        <projectProperty>project[.parent].inceptionYear</projectProperty>
+                        <projectProperty>project[.parent].packaging</projectProperty>
+                        <projectProperty>project[.parent].url</projectProperty>
+                    </projectProperties>
                     <systemProperties>
                         <systemProperty>user.name</systemProperty>
                         <systemProperty>user.timezone</systemProperty>

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ Maven Build Info Plugin
 
 This plugin generates the build-info file which might contain:
 - build date
-- build version
-- source revision (Git, Mercurial or Subversion)
+- project properties (project.artifactId, project.version, project.name, etc.)
 - system properties (user.name, java.vm.vendor, java.vm.version, java.vm.name, os.name, os.version, os.arch, etc.)
+- source revision (Git, Mercurial or Subversion)
 
 If you include this file in the WAR or EAR file, you will not waste time trying to figure out an application's version that is deployed to a server.
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <groupId>com.rodiontsev.maven.plugins</groupId>
-    <artifactId>maven-build-info-plugin</artifactId>
+    <artifactId>build-info-maven-plugin</artifactId>
     <version>1.1-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>2.2.1</version>
+            <version>3.2.2</version>
         </dependency>
 
         <dependency>
@@ -64,52 +64,52 @@
         <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
-            <version>2.3</version>
+            <version>2.6</version>
         </dependency>
 
         <dependency>
              <groupId>commons-io</groupId>
              <artifactId>commons-io</artifactId>
-             <version>2.0.1</version>
+             <version>2.4</version>
          </dependency>
 
         <!-- Mercurial -->
         <dependency>
             <groupId>org.apache.maven.scm</groupId>
             <artifactId>maven-scm-provider-hg</artifactId>
-            <version>1.8.1</version>
+            <version>1.9</version>
         </dependency>
 
         <!-- Git -->
         <dependency>
             <groupId>org.apache.maven.scm</groupId>
             <artifactId>maven-scm-provider-git-commons</artifactId>
-            <version>1.6</version>
+            <version>1.9</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.maven.scm</groupId>
             <artifactId>maven-scm-provider-gitexe</artifactId>
-            <version>1.6</version>
+            <version>1.9</version>
         </dependency>
 
         <!-- Svn -->
         <dependency>
             <groupId>org.apache.maven.scm</groupId>
             <artifactId>maven-scm-provider-svn-commons</artifactId>
-            <version>1.8.1</version>
+            <version>1.9</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.maven.scm</groupId>
             <artifactId>maven-scm-provider-svnexe</artifactId>
-            <version>1.8.1</version>
+            <version>1.9</version>
         </dependency>
 
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
-            <version>1.5.15</version>
+            <version>3.0.17</version>
         </dependency>
     </dependencies>
 
@@ -118,10 +118,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>3.1</version>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>1.6</source>
+                    <target>1.6</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/com/rodiontsev/maven/plugins/buildinfo/BuildInfoMojo.java
+++ b/src/main/java/com/rodiontsev/maven/plugins/buildinfo/BuildInfoMojo.java
@@ -70,6 +70,24 @@ public class BuildInfoMojo extends AbstractMojo {
     private List<String> systemProperties;
 
     /**
+     * Project properties which you would like to include in the generated file.
+     *
+     * project[.parent].id
+     * project[.parent].groupId
+     * project[.parent].artifactId
+     * project[.parent].version
+     * project[.parent].name
+     * project[.parent].description
+     * project[.parent].modelVersion
+     * project[.parent].inceptionYear
+     * project[.parent].packaging
+     * project[.parent].url
+     *
+     * @parameter
+     */
+    private List<String> projectProperties;
+
+    /**
      * Include info from VCS in the generated file
      *
      * @parameter default-value="true"
@@ -115,4 +133,7 @@ public class BuildInfoMojo extends AbstractMojo {
         return includeVcsInfo;
     }
 
+    public List<String> getProjectProperties() {
+        return projectProperties;
+    }
 }

--- a/src/main/java/com/rodiontsev/maven/plugins/buildinfo/BuildInfoMojo.java
+++ b/src/main/java/com/rodiontsev/maven/plugins/buildinfo/BuildInfoMojo.java
@@ -49,7 +49,7 @@ public class BuildInfoMojo extends AbstractMojo {
     /**
      * The Maven Project
      *
-     * @parameter expression="${project}"
+     * @parameter expression="project"
      * @readonly
      */
     private MavenProject project;

--- a/src/main/java/com/rodiontsev/maven/plugins/buildinfo/BuildInfoMojo.java
+++ b/src/main/java/com/rodiontsev/maven/plugins/buildinfo/BuildInfoMojo.java
@@ -83,12 +83,14 @@ public class BuildInfoMojo extends AbstractMojo {
             map.putAll(provider.getInfo(project, this));
         }
 
-        String file = project.getBuild().getDirectory() + File.separator + filename;
-
-        getLog().info("Writing to the file " + file);
+        File buildDir = new File(project.getBuild().getDirectory());
+        File file = new File(buildDir, filename);
 
         Writer out = null;
         try {
+            // we may not have target/ yet
+            buildDir.mkdir();
+            boolean created = file.createNewFile();
             out = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file), "UTF-8"));
             for (Map.Entry<String, String> entry : map.entrySet()) {
                 out.write(entry.getKey());
@@ -97,6 +99,7 @@ public class BuildInfoMojo extends AbstractMojo {
                 out.write("\n");
             }
             out.flush();
+            getLog().info(created ? "Created " : "Overwrote " + file.getAbsolutePath());
         } catch (IOException e) {
             getLog().warn(e.getMessage());
         } finally {

--- a/src/main/java/com/rodiontsev/maven/plugins/buildinfo/providers/ProjectInfoProvider.java
+++ b/src/main/java/com/rodiontsev/maven/plugins/buildinfo/providers/ProjectInfoProvider.java
@@ -36,8 +36,29 @@ public class ProjectInfoProvider implements InfoProvider {
 
     public Map<String, String> getInfo(MavenProject project, BuildInfoMojo mojo) {
         Map<String, String> info = new LinkedHashMap<String, String>();
-        info.put("project.name", project.getName());
-        info.put("project.version", project.getVersion());
+        info.put("project.id",            project.getId());
+        info.put("project.groupId",       project.getGroupId());
+        info.put("project.artifactId",    project.getArtifactId());
+        info.put("project.version",       project.getVersion());
+        info.put("project.name",          project.getName());
+        info.put("project.description",   project.getDescription());
+        info.put("project.modelVersion",  project.getModelVersion());
+        info.put("project.inceptionYear", project.getInceptionYear());
+        info.put("project.packaging",     project.getPackaging());
+        info.put("project.url",           project.getUrl());
+        final MavenProject parent = project.getParent();
+        if (parent != null) {
+            info.put("project.parent.id",            parent.getId());
+            info.put("project.parent.groupId",       parent.getGroupId());
+            info.put("project.parent.artifactId",    parent.getArtifactId());
+            info.put("project.parent.version",       parent.getVersion());
+            info.put("project.parent.name",          parent.getName());
+            info.put("project.parent.description",   parent.getDescription());
+            info.put("project.parent.modelVersion",  parent.getModelVersion());
+            info.put("project.parent.inceptionYear", parent.getInceptionYear());
+            info.put("project.parent.packaging",     parent.getPackaging());
+            info.put("project.parent.url",           parent.getUrl());
+        }
         info.put("build.time", DateFormatUtils.format(new Date(), "d MMMM yyyy, HH:mm:ss ZZ", Locale.ENGLISH));
         return info;
     }

--- a/src/main/java/com/rodiontsev/maven/plugins/buildinfo/providers/ProjectInfoProvider.java
+++ b/src/main/java/com/rodiontsev/maven/plugins/buildinfo/providers/ProjectInfoProvider.java
@@ -35,31 +35,44 @@ import java.util.Map;
 public class ProjectInfoProvider implements InfoProvider {
 
     public Map<String, String> getInfo(MavenProject project, BuildInfoMojo mojo) {
-        Map<String, String> info = new LinkedHashMap<String, String>();
-        info.put("project.id",            project.getId());
-        info.put("project.groupId",       project.getGroupId());
-        info.put("project.artifactId",    project.getArtifactId());
-        info.put("project.version",       project.getVersion());
-        info.put("project.name",          project.getName());
-        info.put("project.description",   project.getDescription());
-        info.put("project.modelVersion",  project.getModelVersion());
-        info.put("project.inceptionYear", project.getInceptionYear());
-        info.put("project.packaging",     project.getPackaging());
-        info.put("project.url",           project.getUrl());
+
+        // finite set of project properties we expose
+        final Map<String, String> props = new LinkedHashMap<String, String>(65);
+        props.put("project.id",            project.getId());
+        props.put("project.groupId",       project.getGroupId());
+        props.put("project.artifactId",    project.getArtifactId());
+        props.put("project.version",       project.getVersion());
+        props.put("project.name",          project.getName());
+        props.put("project.description",   project.getDescription());
+        props.put("project.modelVersion",  project.getModelVersion());
+        props.put("project.inceptionYear", project.getInceptionYear());
+        props.put("project.packaging",     project.getPackaging());
+        props.put("project.url",           project.getUrl());
         final MavenProject parent = project.getParent();
         if (parent != null) {
-            info.put("project.parent.id",            parent.getId());
-            info.put("project.parent.groupId",       parent.getGroupId());
-            info.put("project.parent.artifactId",    parent.getArtifactId());
-            info.put("project.parent.version",       parent.getVersion());
-            info.put("project.parent.name",          parent.getName());
-            info.put("project.parent.description",   parent.getDescription());
-            info.put("project.parent.modelVersion",  parent.getModelVersion());
-            info.put("project.parent.inceptionYear", parent.getInceptionYear());
-            info.put("project.parent.packaging",     parent.getPackaging());
-            info.put("project.parent.url",           parent.getUrl());
+            props.put("project.parent.id",            parent.getId());
+            props.put("project.parent.groupId",       parent.getGroupId());
+            props.put("project.parent.artifactId",    parent.getArtifactId());
+            props.put("project.parent.version",       parent.getVersion());
+            props.put("project.parent.name",          parent.getName());
+            props.put("project.parent.description",   parent.getDescription());
+            props.put("project.parent.modelVersion",  parent.getModelVersion());
+            props.put("project.parent.inceptionYear", parent.getInceptionYear());
+            props.put("project.parent.packaging",     parent.getPackaging());
+            props.put("project.parent.url",           parent.getUrl());
+        }
+
+        // properties the user wants
+        Map<String, String> info = new LinkedHashMap<String, String>();
+
+        for(String propertyName : mojo.getProjectProperties()) {
+            String prop = props.get(propertyName);
+            if (prop != null) {
+                info.put(propertyName, prop);
+            }
         }
         info.put("build.time", DateFormatUtils.format(new Date(), "d MMMM yyyy, HH:mm:ss ZZ", Locale.ENGLISH));
+
         return info;
     }
 


### PR DESCRIPTION
projectProperties is now a configuration element for users to specify which of the available properties to output.
Fixed bug when running with no target folder yet created, e.g. after a clean on some projects.