### PR TITLE
Added support for properties declared within the project itself

### DIFF
--- a/src/main/java/com/rodiontsev/maven/plugins/buildinfo/BuildInfoMojo.java
+++ b/src/main/java/com/rodiontsev/maven/plugins/buildinfo/BuildInfoMojo.java
@@ -11,7 +11,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.rodiontsev.maven.plugins.buildinfo;
 
 import org.apache.commons.io.IOUtils;
@@ -81,6 +80,13 @@ public class BuildInfoMojo extends AbstractMojo {
     private List<String> projectProperties;
 
     /**
+     * Properties declared within the project itself
+     *
+     * @parameter
+     */
+    private List<String> declaredProperties;
+
+    /**
      * System properties, like user.name, java.vm.vendor, java.vm.version, os.name, os.version, etc.,
      * which you would like to include in the generated file
      *
@@ -108,6 +114,7 @@ public class BuildInfoMojo extends AbstractMojo {
      * @parameter default-value="true"
      */
     private boolean includeVcsInfo;
+
 
     public void execute() throws MojoExecutionException, MojoFailureException {
         Map<String, String> map = new LinkedHashMap<String, String>();
@@ -150,6 +157,10 @@ public class BuildInfoMojo extends AbstractMojo {
         return projectProperties;
     }
 
+    public List<String> getDeclaredProperties() {
+        return declaredProperties;
+    }
+
     public List<String> getSystemProperties() {
         return systemProperties;
     }
@@ -165,5 +176,4 @@ public class BuildInfoMojo extends AbstractMojo {
     public boolean isIncludeVcsInfo() {
         return includeVcsInfo;
     }
-
 }

--- a/src/main/java/com/rodiontsev/maven/plugins/buildinfo/providers/DeclaredPropertiesProvider.java
+++ b/src/main/java/com/rodiontsev/maven/plugins/buildinfo/providers/DeclaredPropertiesProvider.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rodiontsev.maven.plugins.buildinfo.providers;
+
+import com.rodiontsev.maven.plugins.buildinfo.BuildInfoMojo;
+import com.rodiontsev.maven.plugins.buildinfo.InfoProvider;
+import com.rodiontsev.maven.plugins.buildinfo.utils.InfoWriter;
+import com.rodiontsev.maven.plugins.buildinfo.utils.PropertyMapper;
+import org.apache.maven.project.MavenProject;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * DeclaredPropertiesProvider adds project's declared properties to the info file.
+ */
+public class DeclaredPropertiesProvider implements InfoProvider
+{
+   @Override
+   public Map< String, String > getInfo( final MavenProject project, final BuildInfoMojo mojo )
+   {
+      Map< String, String > info = new LinkedHashMap< String, String >();
+
+      new InfoWriter().write( info, mojo.getDeclaredProperties(), new PropertyMapper() {
+         @Override
+         public String mapProperty( final String propertyName )
+         {
+            return (String) project.getProperties().get( propertyName );
+         }
+      } );
+
+      return info;
+   }
+}

--- a/src/main/resources/META-INF/services/com.rodiontsev.maven.plugins.buildinfo.InfoProvider
+++ b/src/main/resources/META-INF/services/com.rodiontsev.maven.plugins.buildinfo.InfoProvider
@@ -1,3 +1,4 @@
+com.rodiontsev.maven.plugins.buildinfo.providers.DeclaredPropertiesProvider
 com.rodiontsev.maven.plugins.buildinfo.providers.ProjectPropertiesProvider
 com.rodiontsev.maven.plugins.buildinfo.providers.SystemPropertiesProvider
 com.rodiontsev.maven.plugins.buildinfo.providers.EnvironmentVariablesProvider


### PR DESCRIPTION
This patch adds support for properties declared within the project's pom.xml. This is useful, e.g., if you want to include the version numbers of project dependencies in the build.info output.

Example:
`<properties>`
`   <artemis.version>1.4.0</artemis.version> `
`</properties>`   
` <build>`
`   <plugins>`
`        <plugin>`
`            <groupId>com.rodiontsev.maven.plugins</groupId>`
`             <artifactId>build-info-maven-plugin</artifactId>`
`             <version>1.2-SNAPSHOT</version>`
`             <configuration>`
`                 <filename>classes/build.info</filename>`
`                 <declaredProperties>`
`                    <declaredProperty>artemis.version</declaredProperty>`
`                 </declaredProperties>`
`                 ...`
`             </configuration>`
`         </plugin> `
` ... `